### PR TITLE
Fixed routing not obeying route_prefix set in config

### DIFF
--- a/src/app/Http/routes.php
+++ b/src/app/Http/routes.php
@@ -1,6 +1,6 @@
 <?php
 
-Route::group(['prefix' => 'admin', 'middleware' => ['web', 'auth']], function () {
+Route::group(['prefix' => config('backpack.base.route_prefix', 'admin'), 'middleware' => ['web', 'auth']], function () {
 
     // Backup
     Route::get('backup', 'BackupController@index');

--- a/src/resources/views/backup.blade.php
+++ b/src/resources/views/backup.blade.php
@@ -11,7 +11,7 @@
 	    {{ trans('backpack::backup.backup') }}
 	  </h1>
 	  <ol class="breadcrumb">
-	    <li><a href="{{ url('admin/dashboard') }}">Admin</a></li>
+	    <li><a href="{{ url(config('backpack.base.route_prefix', 'admin').'/dashboard') }}">Admin</a></li>
 	    <li class="active">{{ trans('backpack::backup.backup') }}</li>
 	  </ol>
 	</section>
@@ -21,7 +21,7 @@
 <!-- Default box -->
   <div class="box">
     <div class="box-body">
-      <button id="create-new-backup-button" href="{{ url('admin/backup/create') }}" class="btn btn-primary ladda-button" data-style="zoom-in"><span class="ladda-label"><i class="fa fa-plus"></i> {{ trans('backpack::backup.create_a_new_backup') }}</span></button>
+      <button id="create-new-backup-button" href="{{ url(config('backpack.base.route_prefix', 'admin').'/backup/create') }}" class="btn btn-primary ladda-button" data-style="zoom-in"><span class="ladda-label"><i class="fa fa-plus"></i> {{ trans('backpack::backup.create_a_new_backup') }}</span></button>
       <br>
       <h3>{{ trans('backpack::backup.existing_backups') }}:</h3>
       <table class="table table-hover table-condensed">
@@ -43,9 +43,9 @@
             <td class="text-right">{{ round((int)$b['file_size']/1048576, 2).' MB' }}</td>
             <td class="text-right">
                 @if ($b['download'])
-                <a class="btn btn-xs btn-default" href="{{ url('admin/backup/download/') }}?disk={{ $b['disk'] }}&path={{ urlencode($b['file_path']) }}&file_name={{ urlencode($b['file_name']) }}"><i class="fa fa-cloud-download"></i> {{ trans('backpack::backup.download') }}</a>
+                <a class="btn btn-xs btn-default" href="{{ url(config('backpack.base.route_prefix', 'admin').'/backup/download/') }}?disk={{ $b['disk'] }}&path={{ urlencode($b['file_path']) }}&file_name={{ urlencode($b['file_name']) }}"><i class="fa fa-cloud-download"></i> {{ trans('backpack::backup.download') }}</a>
                 @endif
-                <a class="btn btn-xs btn-danger" data-button-type="delete" href="{{ url('admin/backup/delete/'.$b['file_name']) }}?disk={{ $b['disk'] }}"><i class="fa fa-trash-o"></i> {{ trans('backpack::backup.delete') }}</a>
+                <a class="btn btn-xs btn-danger" data-button-type="delete" href="{{ url(config('backpack.base.route_prefix', 'admin').'/backup/delete/'.$b['file_name']) }}?disk={{ $b['disk'] }}"><i class="fa fa-trash-o"></i> {{ trans('backpack::backup.delete') }}</a>
             </td>
           </tr>
           @endforeach


### PR DESCRIPTION
Fixes #9 
If `route_prefix` is changed in the `backpack.base` config file, the change will now be respected by backup manager.