### PR TITLE
Modernizing syntax used in service providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ $ composer require backpack/backupmanager
 2) Then add the service providers to your config/app.php file:
 
 ```
-'Spatie\Backup\BackupServiceProvider',
-'Backpack\BackupManager\BackupManagerServiceProvider',
+Spatie\Backup\BackupServiceProvider::class,
+Backpack\BackupManager\BackupManagerServiceProvider::class,
 ```
 
 3) Publish the config file and lang files:


### PR DESCRIPTION
Shouldn't this syntax be used for service providers instead, since it's the standard syntax used in Laravel [5.4](https://github.com/laravel/laravel/blob/48f44440f7713d3267af2969ed84297455f3787e/config/app.php#L143), [5.3](https://github.com/laravel/laravel/blob/a9fad67e1fb369779f4c5ebe454524a24e3698b7/config/app.php#L143), [5.2](https://github.com/laravel/laravel/blob/76b8ef720400b0c0bf4cdab39c354e8addef7dd9/config/app.php#L129), and [5.1](https://github.com/laravel/laravel/blob/70f8bb6e08f0232c306826282b995bb5670a0efa/config/app.php#L116)?

The single-quoted string syntax hasn't been used since [5.0](https://github.com/laravel/laravel/blob/7bddbdc2a1f8d9c23205707e74455d74684e3031/config/app.php#L116), so it's about two years old.