### PR TITLE
Typo correction in src/resources/lang/en/backup.php

### DIFF
--- a/src/resources/lang/en/backup.php
+++ b/src/resources/lang/en/backup.php
@@ -22,7 +22,7 @@ return [
     'delete'                             => 'Delete',
     'delete_confirm'                     => 'Are your sure you want to delete this backup file?',
     'delete_confirmation_title'          => 'Done',
-    'delete_confirmation_message'        => 'The backup was file deleted.',
+    'delete_confirmation_message'        => 'The backup file was deleted.',
     'delete_error_title'                 => 'Error',
     'delete_error_message'               => 'The backup file has NOT been deleted.',
     'delete_cancel_title'                => "It's ok",

--- a/src/resources/lang/fr/backup.php
+++ b/src/resources/lang/fr/backup.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Backup Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the backup system.
+    | You are free to change them to anything you want to customize your views to better match your application.
+    |
+    */
+
+    'backup'                             => 'Sauvegarde',
+    'create_a_new_backup'                => 'Créer une nouvelle sauvegarde',
+    'existing_backups'                   => 'Sauvegardes existantes',
+    'date'                               => 'Date',
+    'file_size'                          => 'Taille de fichier',
+    'actions'                            => 'Actions',
+    'download'                           => 'Télécharger',
+    'delete'                             => 'Supprimer',
+    'delete_confirm'                     => 'Etes-vous certain de vouloir supprimer ce fichier ?',
+    'delete_confirmation_title'          => 'Fait',
+    'delete_confirmation_message'        => 'Le fichier de sauvegarde a été supprimmé.',
+    'delete_error_title'                 => 'Erreur',
+    'delete_error_message'               => 'Le fichier de sauvegarde n\'a PAS été supprimmé.',
+    'delete_cancel_title'                => "C'est ok",
+    'delete_cancel_message'              => 'Le fichier de sauvegarde n\'a PAS été supprimmé.',
+    'create_confirmation_title'          => 'Sauvegarde terminée',
+    'create_confirmation_message'        => 'Rechargement de cette page dans 3 secondes.',
+    'create_error_title'                 => 'Erreur de sauvegarde',
+    'create_error_message'               => 'Le fichier de sauvegarde n\'a PAS pu être créer.',
+    'create_warning_title'               => 'Erreur inconnue',
+    'create_warning_message'             => 'Votre fichier de sauvegarde n\'a sans doute pas pu être créé. Regardez les logs pour plus de details.',
+    'location'                           => 'Emplacement',
+    'no_disks_configured'                => 'Aucun "backup disks" de configuré dans config/laravel-backup.php',
+    'backup_doesnt_exist'                => "Le fichier de sauvegarde n'existe pas.",
+    'only_local_downloads_supported'     => 'Seuls les téléchargments à partir du système de fichier local sont supportés.',
+];


### PR DESCRIPTION
`'delete_confirmation_message'        => 'The backup was file deleted.',`
should be:
`'delete_confirmation_message'        => 'The backup file was deleted.',`