### PR TITLE
Flags must be called like an array otherwise will fail

### DIFF
--- a/src/app/Http/Controllers/BackupController.php
+++ b/src/app/Http/Controllers/BackupController.php
@@ -55,6 +55,7 @@ class BackupController extends Controller
             ini_set('max_execution_time', 300);
             // start the backup process
             $flags = config('backup.backup.backpack_flags', false);
+            info("Calling backup:run ",$flags);
 
             if ($flags) {
                 Artisan::call('backup:run', $flags);

--- a/src/config/backup.php
+++ b/src/config/backup.php
@@ -16,7 +16,9 @@ return [
          * --only-files
          * --disable-notifications
          */
-        'backpack_flags' => ['--disable-notifications'],
+        'backpack_flags' => [
+            '--disable-notifications'=>true
+        ],
 
         /*
          * The name of this application. You can use this name to monitor


### PR DESCRIPTION
Flags must be called like an array otherwise will fail
````
'backpack_flags' => [
            '--disable-notifications'=>true
        ],
````

potential fix
https://github.com/Laravel-Backpack/BackupManager/issues/52

in BackupController.php added log with flags to help debugging