### PR TITLE
Updated monitored disk name

### DIFF
--- a/src/config/backup.php
+++ b/src/config/backup.php
@@ -137,7 +137,7 @@ return [
     'monitorBackups' => [
         [
             'name'                                   => env('APP_NAME'),
-            'disks'                                  => ['backup'],
+            'disks'                                  => ['backups'],
             'newestBackupsShouldNotBeOlderThanDays'  => 1,
             'storageUsedMayNotBeHigherThanMegabytes' => 5000,
         ],


### PR DESCRIPTION
Shouldn't this disk be named with the same name for the primary disk driver? Because the default is `backups` and not `backup`.

Am I right?