### PR TITLE
Fix backup create action error message handling

### DIFF
--- a/src/app/Http/Controllers/BackupController.php
+++ b/src/app/Http/Controllers/BackupController.php
@@ -31,13 +31,13 @@ class BackupController extends Controller
                 // only take the zip files into account
                 if (substr($f, -4) == '.zip' && $disk->exists($f)) {
                     $this->data['backups'][] = [
-                        'file_path' => $f,
-                        'file_name' => str_replace('backups/', '', $f),
-                        'file_size' => $disk->size($f),
+                        'file_path'     => $f,
+                        'file_name'     => str_replace('backups/', '', $f),
+                        'file_size'     => $disk->size($f),
                         'last_modified' => $disk->lastModified($f),
-                        'disk' => $disk_name,
-                        'download' => ($adapter instanceof Local) ? true : false,
-                    ];
+                        'disk'          => $disk_name,
+                        'download'      => ($adapter instanceof Local) ? true : false,
+                        ];
                 }
             }
         }
@@ -90,7 +90,7 @@ class BackupController extends Controller
             $storage_path = $disk->getDriver()->getAdapter()->getPathPrefix();
 
             if ($disk->exists($file_name)) {
-                return response()->download($storage_path . $file_name);
+                return response()->download($storage_path.$file_name);
             } else {
                 abort(404, trans('backpack::backup.backup_doesnt_exist'));
             }


### PR DESCRIPTION
## The Issue
Currently, if `backup:run` is failed in certain situation, e.g. `dump.dump_binary_path` not set, the backup process failed but there's nothing written into the log.

**Inspecting `create` method, I find something worth mention:**
a. There's no exception throw from `backup:run`.
b. `\Artican::call('something');` is a synchronous command.

### This commit is about `a.`:

Since `spatie` have already caught exceptions and output as console message,  running `\Artisan::call('backup:run');` won't receive exception from `spatie/laravel-backup`, thus the `try-catch` statement is mostly useless in `create` method.

REF: [BackupCommand.php#L55-L63](https://github.com/spatie/laravel-backup/blob/e3ea9bc9994be5cf8d9e10b202ed838380e0b4e4/src/Commands/BackupCommand.php#L55-L63)
```php
        } catch (Exception $exception) {
            consoleOutput()->error("Backup failed because: {$exception->getMessage()}.");

            if (! $disableNotifications) {
                event(new BackupHasFailed($exception));
            }

            return 1;
        }
```

Also since `spatie/laravel-backup` always print exceptions beginning with `Backup failed because`, I made a slight improvement to the `create` method actually log something into the log.

I think this is a small bug, so I would like to make a PR and see if it helps.

#### Regarding to `b.`:

I'd like to mention this because the `success` message in blade view is titled with `backup has been started, wait a few ... refresh ...`. But the fact is when the message returns, the `Artisan::call()` process had already finished, unless the original thought was to call a job dispatcher.

You may want to improve it, or you won't. This is just about how people would perceive an informative message, it's up to you.
