### PR TITLE
Configurable ini settings for backups

### DIFF
--- a/src/app/Http/Controllers/BackupController.php
+++ b/src/app/Http/Controllers/BackupController.php
@@ -54,8 +54,7 @@ class BackupController extends Controller
         $message = 'success';
 
         try {
-
-            foreach(config('backup.backup.ini_settings') as $setting => $value) {
+            foreach (config('backup.backup.ini_settings') as $setting => $value) {
                 ini_set($setting, $value);
             }
 

--- a/src/app/Http/Controllers/BackupController.php
+++ b/src/app/Http/Controllers/BackupController.php
@@ -54,7 +54,10 @@ class BackupController extends Controller
         $message = 'success';
 
         try {
-            ini_set('max_execution_time', 600);
+
+            foreach(config('backup.backup.ini_settings') as $setting => $value) {
+                ini_set($setting, $value);
+            }
 
             Log::info('Backpack\BackupManager -- Called backup:run from admin interface');
 

--- a/src/config/backup.php
+++ b/src/config/backup.php
@@ -26,6 +26,14 @@ return [
          */
         'name' => env('APP_NAME', 'laravel-backup'),
 
+        /*
+         * Overwrite PHP ini settings when creating the backup
+         */
+
+        'ini_settings' => [
+            'max_execution_time' => 600,
+        ],
+
         'source' => [
 
             'files' => [


### PR DESCRIPTION
refs: #82 

By default we would change ini settings when creating the backup.

Those settings were hardcoded.

Now developer has the chance to change default backpack ini settings values so as to add other settings.