### PR TITLE
add support for spatie v7 and v8 and backpack 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@
 [![Style CI](https://styleci.io/repos/53956594/shield)](https://styleci.io/repos/53956594)
 [![Total Downloads](https://img.shields.io/packagist/dt/backpack/backupmanager.svg?style=flat-square)](https://packagist.org/packages/backpack/backupmanager)
 
-An admin interface for [spatie/laravel-backup](https://github.com/spatie/laravel-backup). Allows the admin to easily manage backups (download and delete). Used in the Backpack package, on Laravel 5.2+ to 6.
+An admin interface for [spatie/laravel-backup](https://github.com/spatie/laravel-backup). Allows the admin to easily manage backups (download and delete). Used in the Backpack package, on Laravel 5.2+ to 9.
 
 
 > ### Security updates and breaking changes
-> Please **[subscribe to the Backpack Newsletter](http://backpackforlaravel.com/newsletter)** so you can find out about any security updates, breaking changes or major features. We send an email every 1-2 months.
-![Backpack\BackupManager screenshot](https://backpackforlaravel.com/uploads/screenshots/backups_running.png)
+> Please **[subscribe to the Backpack Newsletter](http://backpackforlaravel.com/newsletter)** so you can find out about any security updates, breaking changes or major features. We send an email 2 times/year, max.
+
+![Backpack\BackupManager screenshot](https://user-images.githubusercontent.com/1032474/150080754-97dca93f-3cac-452b-9bcf-cc51becd3055.png)
 
 
 ## Install

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "backpack/crud": "^4.1.0",
-        "spatie/laravel-backup": "^6.1"
+        "backpack/crud": "^4.1.0|^4.2.0",
+        "spatie/laravel-backup": "^8.0|^7.0|^6.1"
     },
     "require-dev": {
         "phpunit/phpunit" : "^9.0||^7.0",


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Could not install Backpack on Laravel 9 in the demo. Because this package used `spatie/laravel-backup` v6, and it needed v8.

### AFTER - What is happening after this PR?

Should be able to install.


## HOW

### How did you achieve that, in technical terms?

Added them in `composer.json`. Turns out they introduced no breaking changes in v7 and v8. Which is weird. That's not like them.


### Is it a breaking change or non-breaking change?

Should be non-breaking.

### How can we test the before & after?

Try to `composer require backpack/backupmanager:"dev-bump-dependencies as 3.9.99"` in a Laravel 9 install (might want to use `laravel/framework:"9.x-dev as 8.9.99"`.
