### PR TITLE
Bugfix check if driver is local is changed in laravel v9

### DIFF
--- a/src/app/Http/Controllers/BackupController.php
+++ b/src/app/Http/Controllers/BackupController.php
@@ -91,6 +91,7 @@ class BackupController extends Controller
             if ($disk->exists($file_name)) {
                 if (method_exists($disk->getAdapter(), 'getPathPrefix')) {
                     $storage_path = $disk->getAdapter()->getPathPrefix();
+
                     return response()->download($storage_path.$file_name);
                 } else {
                     return $disk->download($file_name);

--- a/src/app/Http/Controllers/BackupController.php
+++ b/src/app/Http/Controllers/BackupController.php
@@ -5,7 +5,6 @@ namespace Backpack\BackupManager\app\Http\Controllers;
 use Artisan;
 use Exception;
 use Illuminate\Routing\Controller;
-use League\Flysystem\Adapter\Local;
 use Log;
 use Request;
 use Response;

--- a/src/app/Http/Controllers/BackupController.php
+++ b/src/app/Http/Controllers/BackupController.php
@@ -23,7 +23,7 @@ class BackupController extends Controller
 
         foreach (config('backup.backup.destination.disks') as $disk_name) {
             $disk = Storage::disk($disk_name);
-            $adapter = $disk->getDriver()->getAdapter();
+            $can_download = config("filesystems.disks.$disk_name.driver") == 'local';
             $files = $disk->allFiles();
 
             // make an array of backup files, with their filesize and creation date
@@ -36,7 +36,7 @@ class BackupController extends Controller
                         'file_size'     => $disk->size($f),
                         'last_modified' => $disk->lastModified($f),
                         'disk'          => $disk_name,
-                        'download'      => ($adapter instanceof Local) ? true : false,
+                        'download'      => $can_download ? true : false,
                     ];
                 }
             }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Issue #100 - Call to undefined method League\Flysystem\Filesystem::getAdapter()

In laravel v9, league/flysystem package has beed upgraded. As a result `$disk->getDriver()->getAdapter()` does not exist. We can use `$disk->getAdapter()` instead.
https://github.com/Laravel-Backpack/BackupManager/blob/4c1878c4edfd37c0d2aa0adbe81add9dcb56d274/src/app/Http/Controllers/BackupController.php#L26
However, this will either break `($adapter instanceof Local)` either lose backwards compatibility with older laravel versions.
In laravel < 9 - `$disk->getAdapter()` is instance of `League\Flysystem\Adapter\Local`
In laravel >= 9.* - `$disk->getAdapter()` is instance of `League\Flysystem\Local\LocalFilesystemAdapter`

Also the download operation is broken because `$disk->getAdapter()->getPathPrefix()` does not exist anymore.
https://github.com/thephpleague/flysystem/blob/3.x/src/Local/LocalFilesystemAdapter.php


### AFTER - What is happening after this PR?

An easier solution is to just check the driver name.
`config("filesystems.disks.$disk_name.driver") == 'local'`

For the download operation i used `$disk->download($file_name);` documented here:
https://laravel.com/docs/9.x/filesystem#downloading-files


## HOW

### How did you achieve that, in technical terms?

`config("filesystems.disks.$disk_name.driver") == 'local'`
```php
if (method_exists($disk->getAdapter(), 'getPathPrefix')) {
    // to keep backwards compatibility
    $storage_path = $disk->getAdapter()->getPathPrefix();
    return response()->download($storage_path.$file_name);
} else {
    return $disk->download($file_name);
}
```


### Is it a breaking change or non-breaking change?

No


### How can we test the before & after?

Install laravel v9 with backpack v5 and this backup manager, then just navigate to `/admin/backup`


A future update/improvement is to show the download link with any disk driver, and use `Storage::url` or `Storage::temporaryUrl`