### PR TITLE
Fix Timezone/Added Italian Language

### DIFF
--- a/src/app/Http/Controllers/BackupController.php
+++ b/src/app/Http/Controllers/BackupController.php
@@ -40,7 +40,7 @@ class BackupController extends Controller
                         'filePath'     => $file,
                         'fileName'     => $fileName,
                         'fileSize'     => round((int) $disk->size($file) / 1048576, 2),
-                        'lastModified' => Carbon::createFromTimeStamp($disk->lastModified($file), date_default_timezone_get())->isoFormat('DD MMMM YYYY, HH:mm'),
+                        'lastModified' => Carbon::createFromTimeStamp($disk->lastModified($file), config('app.timezone'))->isoFormat('DD MMMM YYYY, HH:mm'),
                         'diskName'     => $diskName,
                         'downloadLink' => is_a($disk->getAdapter(), LocalFilesystemAdapter::class, true) ? $downloadLink : null,
                         'deleteLink'   => $deleteLink,

--- a/src/app/Http/Controllers/BackupController.php
+++ b/src/app/Http/Controllers/BackupController.php
@@ -40,7 +40,7 @@ class BackupController extends Controller
                         'filePath'     => $file,
                         'fileName'     => $fileName,
                         'fileSize'     => round((int) $disk->size($file) / 1048576, 2),
-                        'lastModified' => Carbon::createFromTimeStamp($disk->lastModified($file))->isoFormat('DD MMMM YYYY, HH:mm'),
+                        'lastModified' => Carbon::createFromTimeStamp($disk->lastModified($file), date_default_timezone_get())->isoFormat('DD MMMM YYYY, HH:mm'),
                         'diskName'     => $diskName,
                         'downloadLink' => is_a($disk->getAdapter(), LocalFilesystemAdapter::class, true) ? $downloadLink : null,
                         'deleteLink'   => $deleteLink,

--- a/src/resources/lang/it/backup.php
+++ b/src/resources/lang/it/backup.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Backup Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the backup system.
+    | You are free to change them to anything you want to customize your views to better match your application.
+    |
+    */
+
+    'backup'                         => 'Backup',
+    'backups'                        => 'Backups',
+    'create_a_new_backup'            => 'Crea un nuovo backup',
+    'existing_backups'               => 'Backups esistenti',
+    'date'                           => 'Data',
+    'file_size'                      => 'Dimensione file',
+    'actions'                        => 'Azioni',
+    'download'                       => 'Download',
+    'delete'                         => 'Elimina',
+    'delete_confirm'                 => 'Sei sicuro di voler eliminare questo file di backup?',
+    'delete_confirmation_title'      => 'Fatto',
+    'delete_confirmation_message'    => 'Il file di backup è stato eliminato.',
+    'delete_error_title'             => 'Errore',
+    'delete_error_message'           => 'Il file di backup NON è stato eliminato.',
+    'delete_cancel_title'            => 'Tutto a posto',
+    'delete_cancel_message'          => 'Il file di backup NON è stato eliminato.',
+    'create_confirmation_title'      => 'Processo di backup avviato.',
+    'create_error_title'             => 'Errore backup',
+    'create_error_message'           => 'Non è stato possibile creare il file di backup.',
+    'create_warning_title'           => 'Errore sconosciuto',
+    'create_warning_message'         => 'Il backup potrebbe NON essere stato creato. Per favore controlla i log file per dettagli.',
+    'location'                       => 'Posizione',
+    'no_disks_configured'            => 'Nessun disco per il backup configurato in config/backup.php',
+    'backup_doesnt_exist'            => 'Il file di backup non esiste.',
+    'only_local_downloads_supported' => 'Sono supportati solo i download dal file system locale.',
+    'unknown_disk'                   => 'Disco sconosciuto.',
+    'create_started_message'         => 'Per favore attendi alcuni minuti per il completamento.',
+    'create_completed_title'         => 'Il backup è completato.',
+    'download_confirmation_title'    => 'Processo di download avviato.',
+    'download_error_title'           => 'Errore download',
+];


### PR DESCRIPTION
Correct hours and minutes are shown using user's timezone.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

isoFormat did not take user's timezone into account.

### AFTER - What is happening after this PR?

Correct hours and minutes are shown.

## HOW

### How did you achieve that, in technical terms?

Adding date_default_timezone_get() as second parameter for createFromTimeStamp() function.

### Is it a breaking change or non-breaking change?

Non-breaking

### How can we test the before & after?

Check if hours and minutes are shown correctly.
