### PR TITLE
Bump versions for major release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "backpack/backupmanager",
     "description": "Admin interface for managing backups in Backpack, on Laravel 5.2+",
     "keywords": [
-        "dick",
         "backpack",
         "updivision",
         "backup",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "backpack/crud": "^6.0",
-        "spatie/laravel-backup": "^8.0"
+        "backpack/crud": "dev-next as 6.99.9",
+        "spatie/laravel-backup": "^9.0"
     },
     "require-dev": {
         "scrutinizer/ocular": "~1.7|~1.1"


### PR DESCRIPTION
This PR requires the new Backpack version (v7), and bump spatie backup version. 